### PR TITLE
Desplegar resultados

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,4 @@
-PORT=3000
+PORT=5000
 
 GUARDIAN_API_URL=https://content.guardianapis.com/search
 GUARDIAN_API_KEY=ee80c7d1-3aa6-4189-a6f8-491d37a95fdf

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE_URL=http://localhost:3000
+REACT_APP_API_BASE_URL=http://localhost:5000

--- a/frontend/src/components/AdComparison.js
+++ b/frontend/src/components/AdComparison.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
 function AdComparison({ results }) {
+  console.log('Results:', results);
+
   return (
     <div className="ad-comparison">
       {Object.entries(results).map(([source, ads]) => (
@@ -10,7 +12,7 @@ function AdComparison({ results }) {
             <div key={index} className="ad">
               <h3>{ad.title}</h3>
               <p>{ad.description}</p>
-              {ad.price && <p className="price">Price: {ad.price}</p>}
+              {ad.date && <p className="date">Date: {ad.date}</p>}
               {ad.link && (
                 <a href={ad.link} target="_blank" rel="noopener noreferrer" className="ad-link">
                   View Ad

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,11 +1,20 @@
 import axios from 'axios';
+import { normalizeGuardianAd, normalizeTimesAd } from '../utils/normalizeArticles';
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
 
 export async function searchAds(query) {
   try {
     const response = await axios.post(`${API_BASE_URL}/api/search`, { query });
-    return response.data;
+    const data = response.data;
+
+    // Normalize data
+    const normalizedData = {
+      Guardian: data.Guardian.map(normalizeGuardianAd),
+      Times: data.Times.map(normalizeTimesAd),
+    };
+
+    return normalizedData;
   } catch (error) {
     console.error('Error fetching ads:', error);
     throw error;

--- a/frontend/src/utils/normalizeArticles.js
+++ b/frontend/src/utils/normalizeArticles.js
@@ -1,0 +1,18 @@
+// para el componente que requiere el mismo formato de json
+export function normalizeGuardianAd(ad) {
+  return {
+    title: ad.webTitle || 'No Title',
+    description: ad.fields?.trailText || ad.sectionName || 'No Description',
+    date: ad.webPublicationDate || '', 
+    link: ad.webUrl || ''
+  };
+}
+
+export function normalizeTimesAd(ad) {
+  return {
+    title: ad.headline?.main || 'No Title',
+    description: ad.snippet || 'No Description',
+    date: ad.pub_date || '', 
+    link: ad.web_url || ''
+  };
+}


### PR DESCRIPTION
El problema era que el componente que se utilizaba estaba normalizado a sacar 4 cosas de un objeto: title, description, price y link.
Sin embargo, los objetos no tenían estos componentes, además de que habían dos diferentes tipos de objetos (De TheGuardian y de TheNewYorkTimes).
Por eso, ahora se normalizan los objetos después de obtenerlos